### PR TITLE
SCRUM-36: Reactive refresh + silent refresh on reload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,10 +8,12 @@ function App() {
   const dispatch = useDispatch();
 
   useEffect(() => {
+    const controller = new AbortController();
     (async () => {
       try {
         const { data } = await refreshClient.post("", {}, {
           withCredentials: true, // send refresh cookie
+          signal: controller.signal,
         });
         console.warn(data);
         if (data?.accessToken) {
@@ -24,6 +26,10 @@ function App() {
         dispatch(logout({ message: error.message }));
       }
     })();
+    return () => {
+      controller.abort();
+      dispatch(logout());
+    };
   }, [dispatch]);
   return (
     <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,30 @@
 import AppRoutes from "./app/routes";
-
-// should be removed
-// import { useAuth } from "@/features/auth/hooks/useAuth"; 
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { loginSuccess, logout } from "./features/auth/store/auth.slice";
+import { refreshClient } from "./libs/axios";
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { data } = await refreshClient.post("", {}, {
+          withCredentials: true, // send refresh cookie
+        });
+        console.warn(data);
+        if (data?.accessToken) {
+          dispatch(loginSuccess(data));
+        } else {
+          dispatch(logout(data));
+        }
+      } catch (error) {
+        console.warn(error);
+        dispatch(logout({ message: error.message }));
+      }
+    })();
+  }, [dispatch]);
   return (
     <>
       <AppRoutes />

--- a/src/app/routes/HomeRoute.jsx
+++ b/src/app/routes/HomeRoute.jsx
@@ -1,12 +1,14 @@
 import UserHomePage from "../../features/users/pages/UserHomePage";
 import AdminHomePage from "../../features/admin/pages/AdminHomePage";
+import { useSelector } from "react-redux";
 
 const HomeRoute = () => {
   // TODO: Implement authentication state based on the role (user and admin)
   // const user = { role: "admin" };
-  const user = { role: 'user' };
+  // const user = { role: 'user' };
+  const user = useSelector((state) => state.auth.user)
 
-  if (user && user.role === "admin") {
+  if (user && user.role !== "normal") {
     return <AdminHomePage />;
   }
 

--- a/src/app/routes/ProtectedRoute.jsx
+++ b/src/app/routes/ProtectedRoute.jsx
@@ -21,7 +21,7 @@ const ProtectedRoute = ({ adminOnly = false }) => {
   }
 
   // Check admin access for admin-only routes
-  if (adminOnly && (!user || user.role !== "admin")) {
+  if (adminOnly && (!user || user.role === "normal")) {
     return <Navigate to={PATHS.HOME} replace />;
   }
 

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -4,8 +4,9 @@ import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
 import { useSelector, useDispatch } from 'react-redux';
 import { PATHS } from '../app/config/paths';
-import { logout } from '@/features/auth/store/auth.slice';
+import { logout } from '../features/auth/store/auth.slice';
 import { logoutUser } from '../features/auth/api/auth.api';
+import { isAxiosError } from 'axios';
 
 export const NavigationBar = () => {
   const user = useSelector((state) => state.auth.user);
@@ -13,9 +14,15 @@ export const NavigationBar = () => {
   const navigate = useNavigate();
 
   const handleLogout = async () => {
-    const response = await logoutUser();
-    dispatch(logout(response));
-    navigate(PATHS.ROOT);
+    try {
+      const response = await logoutUser();
+      dispatch(logout(response));
+    } catch (error) {
+      if (isAxiosError(error) && error.status === 401)
+        return;
+    } finally {
+      navigate(PATHS.ROOT);
+    }
   };
 
   return (

--- a/src/features/auth/pages/Login.jsx
+++ b/src/features/auth/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 
 import { loginStart, loginSuccess, loginFailure } from "../store/auth.slice";
@@ -14,7 +14,7 @@ const Login = () => {
   });
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { error, loading } = useSelector((state) => state.auth);
+  const { user, error, loading } = useSelector((state) => state.auth);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -63,6 +63,7 @@ const Login = () => {
     };
   }, []); // also clean up credentials at unmount;
 
+  if (user) return <Navigate to={PATHS.HOME} />;
   return (
     <div>
       <h2>Login</h2>

--- a/src/features/auth/store/auth.listener.js
+++ b/src/features/auth/store/auth.listener.js
@@ -1,0 +1,33 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit';
+import { loginSuccess, updateIdentitySuccess, logout } from './auth.slice';
+import { tokenService } from '@/libs/tokenService'
+
+const authListenerMiddleware = createListenerMiddleware();
+
+authListenerMiddleware.startListening({
+  actionCreator: loginSuccess,
+  effect: async (action, { extra }) => {
+    const token = action.payload.accessToken;
+    localStorage.setItem('token', token);
+    tokenService.set(token);
+  }
+});
+
+authListenerMiddleware.startListening({
+  actionCreator: logout,
+  effect: async (action, { extra }) => {
+    localStorage.removeItem('token');
+    tokenService.clear();
+  }
+});
+
+authListenerMiddleware.startListening({
+  actionCreator: updateIdentitySuccess,
+  effect: async (action, { extra }) => {
+    const token = action.payload.accessToken;
+    localStorage.setItem('token', token);
+    tokenService.set(token);
+  }
+});
+
+export default authListenerMiddleware;

--- a/src/features/auth/store/auth.slice.js
+++ b/src/features/auth/store/auth.slice.js
@@ -1,6 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { jwtDecode } from "jwt-decode";
 
+/*
 const token = localStorage.getItem("token");
 let user = null;
 
@@ -12,10 +13,11 @@ if (token) {
     localStorage.removeItem("token");
   }
 }
+*/
 
 const initialState = {
-  user,
-  token,
+  user: null,
+  token: null,
   loading: false,
   error: null,
   message: null,
@@ -37,10 +39,8 @@ const authSlice = createSlice({
       const { accessToken, message } = action.payload;
       state.token = accessToken;
 
-      const tokenPayload = jwtDecode(accessToken);
-      state.user = tokenPayload.sub;
-
-      localStorage.setItem("token", accessToken);
+      const { sub: id, email, role, emailVerified } = jwtDecode(accessToken);
+      state.user = { id, email, role, emailVerified };
 
       state.message = message;
     },
@@ -53,7 +53,6 @@ const authSlice = createSlice({
       state.user = null;
       state.token = null;
       state.error = null;
-      localStorage.removeItem("token");
       state.message = action.payload.message;
     },
 
@@ -86,10 +85,8 @@ const authSlice = createSlice({
       const { accessToken, message } = action.payload;
       state.token = accessToken;
 
-      const tokenPayload = jwtDecode(accessToken);
-      state.user = tokenPayload.sub;
-
-      localStorage.setItem("token", accessToken);
+      const { sub: id, email, role, emailVerified } = jwtDecode(accessToken);
+      state.user = { id, email, role, emailVerified };
 
       state.message = message;
     },

--- a/src/libs/axios.js
+++ b/src/libs/axios.js
@@ -1,5 +1,7 @@
 import axios from "axios";
-import { API_CONFIG } from "@/config/api.config";
+import { API_CONFIG } from "../config/api.config";
+import { loginSuccess, logout } from "../features/auth/store/auth.slice";
+import { store } from "../store/store";
 
 const apiClient = axios.create({
   baseURL: API_CONFIG.BASE_URL,
@@ -22,16 +24,96 @@ apiClient.interceptors.request.use((config) => {
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+  config.withCredentials = true;
   return config;
 });
 
 // Auth interceptor for responses
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
-    console.error("API Error:", error);
+  async (error) => {
+    console.warn("API Error:", error);
+
+    const status = error?.response?.status;
+    const config = error?.config;
+
+    // only handle 401 once per request
+    if (config && status === 401 && !config._retry && !SKIP_AUTH)
+      return await handle401(error);
+
     return Promise.reject(error);
   }
 );
+
+
+// Separate client for reactive refresh
+export const refreshClient = axios.create({
+  baseURL: `${API_CONFIG.BASE_URL}${API_CONFIG.ENDPOINTS.AUTH.REFRESH}`,
+  timeout: API_CONFIG.TIMEOUT,
+  headers: { "Content-Type": "application/json" },
+});
+
+// refresh state
+let isRefreshing = false;
+const waiters = [];
+
+const notifyAll = (token) => {
+  waiters.forEach((cb) => cb(token));
+  waiters.length = 0;
+};
+
+const queueForRefresh = () =>
+  new Promise((resolve) => {
+    waiters.push((token) => resolve(token));
+  });
+
+const handle401 = async (error) => {
+  const config = error.config;
+  config._retry = true;
+
+  // If a refresh is already running, wait for it, then retry
+  if (isRefreshing) {
+    const token = await queueForRefresh();
+    if (!token) return Promise.reject(error); // refresh failed elsewhere
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+    return apiClient(config);
+  }
+
+  // Start a new refresh
+  isRefreshing = true;
+  try {
+    const { data } = await refreshClient.post(
+      '',
+      {},
+      { withCredentials: true } // cookie carries refresh token
+    );
+    const newAccess = data?.accessToken;
+
+    if (!newAccess) {
+      // Unexpected payload -> treat as failure
+      store.dispatch(logout({message: "Failed to get new access token"}));
+      notifyAll(null);
+      return Promise.reject(error);
+    }
+
+    // Update Redux store
+    store.dispatch(loginSuccess(data));
+    notifyAll(newAccess);
+
+    // Retry original with new token
+    config.headers = config.headers ?? {};
+    config.headers.Authorization = `Bearer ${newAccess}`;
+    return apiClient(config);
+
+  } catch (e) {
+    // Refresh failed -> logout and reject everyone
+    store.dispatch(logout({message: "Failed to refresh"}));
+    notifyAll(null);
+    return Promise.reject(e);
+  } finally {
+    isRefreshing = false;
+  }
+};
 
 export default apiClient;

--- a/src/libs/tokenService.js
+++ b/src/libs/tokenService.js
@@ -1,0 +1,8 @@
+let token = null;
+
+// On app start (or after /auth/refresh), call tokenService.set(accessToken)
+export const tokenService = {
+  get: () => token,
+  set: (t) => { token = t; },
+  clear: () => { token = null; },
+};

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,5 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import authReducer from "../features/auth/store/auth.slice";
+import authListenerMiddleware from "../features/auth/store/auth.listener";
+import { adminUserApi } from '../features/admin/users.api';
 
 const store = configureStore({
   reducer: {
@@ -8,6 +10,10 @@ const store = configureStore({
     // posts: postsReducer,
     // etc...
   },
+  middleware: (getDefault) =>
+    getDefault()
+      .prepend(authListenerMiddleware.middleware)
+      .concat(adminUserApi.middleware),
 });
 
 export { store };


### PR DESCRIPTION
## Summary

This PR implements **authentication token refresh handling** for the client app.

## Changes

* Added **Axios interceptor logic** for reactive refresh on `401 Unauthorized`.
* Ensured only one refresh request runs at a time; queued requests retry after refresh.
* Implemented **app-level silent refresh** on initial load to update Redux with a valid token.
* Updated **auth state structure** in Redux (`state.auth.user`).
* Centralized token usage via shared `apiClient` (`@/libs/axios`).

## Notes

* Tokens are now fully managed through the Axios client and Redux store.
* Direct access to tokens is discouraged — use `apiClient` for API requests.
